### PR TITLE
Fix/auth

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,9 +1,9 @@
-import { IUser } from '../models/userModel';
-
+import { Types } from 'mongoose';
 declare global {
   namespace Express {
     interface Request {
-      user?: IUser;
+      userId?: Types.ObjectId;
+      userRole?: string;
     }
   }
 }

--- a/src/controller/authController.ts
+++ b/src/controller/authController.ts
@@ -3,9 +3,10 @@ import * as authService from '../service/authService';
 
 export const join = async (req: Request, res: Response, next: NextFunction) => {
   try {
+    const url: string = `${req.protocol}://${req.get('host')}`;
     const userData = req.body;
     // FIXME: 지금은 테스트를 위해서 유저 정보를 리턴받는데 나중에는 안 받아도 됨.
-    const newUser = await authService.join(userData);
+    const newUser = await authService.join(url, userData);
 
     res.status(201).json({
       status: 'success',

--- a/src/controller/authController.ts
+++ b/src/controller/authController.ts
@@ -4,6 +4,7 @@ import * as authService from '../service/authService';
 export const join = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const userData = req.body;
+    // FIXME: 지금은 테스트를 위해서 유저 정보를 리턴받는데 나중에는 안 받아도 됨.
     const newUser = await authService.join(userData);
 
     res.status(201).json({
@@ -25,6 +26,7 @@ export const login = async (
 ) => {
   try {
     const userData = req.body;
+    // FIXME: 지금은 테스트를 위해서 유저 정보를 리턴받는데 나중에는 안 받아도 됨.
     const { updatedUser, accessToken, refreshToken } = await authService.login(
       userData,
     );
@@ -64,12 +66,14 @@ export const protect = async (
   next: NextFunction,
 ) => {
   try {
-    const { user, newAccessToken } = await authService.protect(
+    const { userId, userRole, newAccessToken } = await authService.protect(
       req.cookies.accessToken,
       req.cookies.refreshToken,
     );
 
-    req.user = user;
+    req.userId = userId;
+    req.userRole = userRole;
+
     if (newAccessToken !== '') {
       res.cookie('accessToken', newAccessToken, {
         expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),

--- a/src/controller/majorController.ts
+++ b/src/controller/majorController.ts
@@ -45,7 +45,6 @@ export const getMajor = async (
   next: NextFunction,
 ) => {
   try {
-    req.user;
     const majorId = req.params.id;
     const major = await majorService.getMajor(majorId);
     res.status(200).json({

--- a/src/controller/messageController.ts
+++ b/src/controller/messageController.ts
@@ -1,7 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import * as messageService from '../service/messageService';
 import mongoose from 'mongoose';
-import { IUser } from '../models/userModel';
 
 export const getAllMessages = async (
   req: Request,
@@ -9,27 +8,30 @@ export const getAllMessages = async (
   next: NextFunction,
 ) => {
   try {
-    const user = req.user as IUser;
+    const userId = req.userId as mongoose.Types.ObjectId;
     const currentPage = Number(req.query.page);
-    const messages = await messageService.getAllMessages(user, currentPage);
+    const messages = await messageService.getAllMessages(userId, currentPage);
     res.status(200).json(messages);
   } catch (err) {
     next(err);
   }
 };
 
-export const getConversationBtwUsers =async (
+export const getConversationBtwUsers = async (
   req: Request,
   res: Response,
   next: NextFunction,
 ) => {
   try {
     //sender는 로그인 정보로, receiver nickname을 parameter로 받아와서 service 단에 전달한다.
-    const sender = req.user as IUser;
-    const senderId = sender._id;
+    const senderId = req.userId as mongoose.Types.ObjectId;
     const receiverNickname = req.params.receiverNickname;
     const currentPage = Number(req.query.page);
-    const messages = await messageService.getConversationBtwUsers(senderId, receiverNickname, currentPage);
+    const messages = await messageService.getConversationBtwUsers(
+      senderId,
+      receiverNickname,
+      currentPage,
+    );
     res.status(200).json(messages);
   } catch (err) {
     next(err);
@@ -43,9 +45,9 @@ export const createMessage = async (
 ) => {
   try {
     //sender 정보는 로그인 정보로, receiver nickname과 content를 body로 받아와서 service에 전달한다.
-    const sender = req.user as IUser;
+    const senderId = req.userId as mongoose.Types.ObjectId;
     const { receiverNickname, content } = req.body;
-    const messageData = {sender, receiverNickname, content};
+    const messageData = { senderId, receiverNickname, content };
     const createdMessage = await messageService.createMessage(messageData);
     res.status(201).json(createdMessage);
   } catch (err) {

--- a/src/controller/postController.ts
+++ b/src/controller/postController.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import * as postService from '../service/postService';
-import { Types as MongooseTypes } from 'mongoose';
+import mongoose, { Types as MongooseTypes } from 'mongoose';
 import { IUser } from '../models/userModel';
 
 export const getAllPosts = async (
@@ -9,9 +9,9 @@ export const getAllPosts = async (
   next: NextFunction,
 ) => {
   try {
-    const user = req.user as IUser; //유저 정보를 받아오도록 수정
+    const userId = req.userId as mongoose.Types.ObjectId;
     const currentPage = Number(req.query.page);
-    const posts = await postService.getAllPosts(user, currentPage);
+    const posts = await postService.getAllPosts(userId, currentPage);
     res.status(200).json(posts);
   } catch (err) {
     next(err);
@@ -25,14 +25,14 @@ export const createPost = async (
 ) => {
   try {
     //body와 user 정보를 합쳐 post를 구성하는 정보를 service에 넘긴다.
-    const user = req.user as IUser;
+    const userId = req.userId as mongoose.Types.ObjectId;
     const { title, content, category } = req.body;
     const postData = {
-      userId : user._id,
+      userId,
       title,
       content,
-      category
-    }
+      category,
+    };
     const createdPost = await postService.createPost(postData);
     res.status(201).json(createdPost);
   } catch (err) {
@@ -40,7 +40,7 @@ export const createPost = async (
   }
 };
 
-export const deletePost =async (
+export const deletePost = async (
   req: Request,
   res: Response,
   next: NextFunction,
@@ -56,4 +56,4 @@ export const deletePost =async (
   } catch (err) {
     next(err);
   }
-}
+};

--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -22,7 +22,7 @@ type userDataType = {
   hopeMajors: Array<string> | null;
 };
 
-export const join = async (userData: userDataType) => {
+export const join = async (url: string, userData: userDataType) => {
   const firstMajorName = userData.firstMajor;
   const secondMajorName = userData.secondMajor;
   const firstMajor = (await Major.findOne({
@@ -65,7 +65,7 @@ export const join = async (userData: userDataType) => {
     });
   }
   const certificateToken = jwt.createCertificateToken(newUser);
-  await email.sendAuthEmail(newUser.name, newUser.email, certificateToken);
+  await email.sendAuthEmail(url, newUser.name, newUser.email, certificateToken);
   await newUser.save();
   return newUser;
 };

--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -1,51 +1,72 @@
+import { Types } from 'mongoose';
 import User, { IUser } from '../models/userModel';
 import Major, { IMajor } from '../models/majorModel';
 import * as jwt from '../utils/jwt';
 import * as email from '../utils/email';
 
-export const join = async (userInfo: IUser) => {
-  const firstMajorName = userInfo.firstMajor;
-  const firstMajor: IMajor | null = await Major.findOne({
+type userDataType = {
+  password: string;
+  studentId: number;
+  email: string;
+  firstMajor: string;
+  name: string;
+  nickname: string;
+  role: string;
+  refreshToken: string;
+  certificate: string;
+  secondMajor: string;
+  passSemester: string;
+  passDescription: string;
+  passGPA: number;
+  wannaSell: boolean;
+  hopeMajors: Array<string> | null;
+};
+
+export const join = async (userData: userDataType) => {
+  const firstMajorName = userData.firstMajor;
+  const secondMajorName = userData.secondMajor;
+  const firstMajor = (await Major.findOne({
     name: firstMajorName,
-  }).exec();
-  const secondMajorName = userInfo.secondMajor;
-  let newUser: IUser;
+  })) as IMajor;
+
+  let newUser;
 
   if (!secondMajorName) {
     // candidate
-    newUser = await User.create({
-      password: userInfo.password,
-      studentId: userInfo.studentId,
-      email: userInfo.email,
-      firstMajor: firstMajor!._id,
-      name: userInfo.name,
-      nickname: userInfo.nickname,
-      role: userInfo.role,
-      hopeMajors: userInfo.hopeMajors,
+    newUser = new User({
+      password: userData.password,
+      studentId: userData.studentId,
+      email: userData.email,
+      firstMajor: firstMajor._id,
+      name: userData.name,
+      nickname: userData.nickname,
+      role: userData.role,
+      hopeMajors: userData.hopeMajors,
     });
   } else {
     // passer
-    const secondMajor: IMajor | null = await Major.findOne({
+    const secondMajor = (await Major.findOne({
       name: secondMajorName,
-    }).exec();
+    })) as IMajor;
 
-    newUser = await User.create({
-      password: userInfo.password,
-      studentId: userInfo.studentId,
-      email: userInfo.email,
-      firstMajor: firstMajor!._id,
-      name: userInfo.name,
-      nickname: userInfo.nickname,
-      role: userInfo.role,
-      secondMajor: secondMajor!._id,
-      passSemester: userInfo.passSemester,
-      passDescription: userInfo.passDescription,
-      passGPA: userInfo.passGPA,
-      wannaSell: userInfo.wannaSell,
+    newUser = new User({
+      password: userData.password,
+      studentId: userData.studentId,
+      email: userData.email,
+      firstMajor: firstMajor._id,
+      name: userData.name,
+      nickname: userData.nickname,
+      role: userData.role,
+      secondMajor: secondMajor._id,
+      passSemester: userData.passSemester,
+      passDescription: userData.passDescription,
+      passGPA: userData.passGPA,
+      wannaSell: userData.wannaSell,
     });
   }
   const certificateToken = jwt.createCertificateToken(newUser);
   await email.sendAuthEmail(newUser.name, newUser.email, certificateToken);
+  await newUser.save();
   return newUser;
 };
 
@@ -85,8 +106,8 @@ export const login = async (userData: IUser) => {
 
 export const logout = async (accessToken: string) => {
   if (accessToken) {
-    const userId = jwt.decodeToken(accessToken);
-    await User.findByIdAndUpdate(userId, { refreshToken: null });
+    const { id } = jwt.decodeToken(accessToken);
+    await User.findByIdAndUpdate(id, { refreshToken: null });
   }
 };
 
@@ -97,6 +118,8 @@ export const protect = async (accessToken: string, refreshToken: string) => {
   }
 
   let newAccessToken: string = '';
+  let userId: Types.ObjectId;
+  let userRole: string;
 
   // 2) accessToken이 유효한지 확인
   const accessResult = jwt.verifyToken(accessToken);
@@ -104,8 +127,8 @@ export const protect = async (accessToken: string, refreshToken: string) => {
   if (accessResult === null) {
     // 2 - 2) accessToken 만료되었음
     // 3) user model에서 refreshToken 가져오고 유효한지 확인
-    const userId = jwt.decodeToken(accessToken);
-    const user = await User.findById(userId);
+    const { id } = jwt.decodeToken(accessToken);
+    const user = await User.findById(id);
 
     if (!user || !user.refreshToken)
       throw {
@@ -116,8 +139,8 @@ export const protect = async (accessToken: string, refreshToken: string) => {
     if (jwt.verifyRefreshToken(user.refreshToken)) {
       // 3 - 1) refreshToken 유효하다면 accessToken 새로 발급하고 user와 accessToken 리턴
       newAccessToken = jwt.createToken(user);
-
-      return { user, newAccessToken };
+      userId = user.id;
+      userRole = user.role;
     } else {
       // 3 - 2) refreshToken도 만료되었다면 새로 로그인하도록 throw error.
       throw {
@@ -126,21 +149,17 @@ export const protect = async (accessToken: string, refreshToken: string) => {
       };
     }
   } else {
-    // 2 - 1) accessToken이 유효하다면 유저 리턴
-    const user = await User.findById(accessResult);
-
-    // 실행되는 일 없을 것임, ts에러 떠서 추가.
-
-    if (!user) throw { status: 400, message: 'Bad Request' };
-
-    return { user, newAccessToken };
+    userId = accessResult.id;
+    userRole = accessResult.role;
   }
+
+  return { userId, userRole, newAccessToken };
 };
 
 export const certifyUser = async (certificateToken: string) => {
-  const userId = jwt.decodeToken(certificateToken);
+  const { id } = jwt.decodeToken(certificateToken);
   const updatedUser = await User.findByIdAndUpdate(
-    userId,
+    id,
     { certificate: 'active' },
     {
       new: true,

--- a/src/service/messageService.ts
+++ b/src/service/messageService.ts
@@ -3,19 +3,19 @@ import messageModel from '../models/messageModel';
 import User, { IUser } from '../models/userModel';
 
 export const getAllMessages = async (
-  user : IUser,
-  page : number
+  userId: mongoose.Types.ObjectId,
+  page: number,
 ) => {
   try {
-    const userId = user._id;
     const itemsPerPage = 10;
     // 본인(user)이 받은 or 보낸 message 조회
-    const messages = await messageModel.find({
-      $or: [
-        { sender: userId }, 
-        { receiver: userId }
-      ],
-    }).skip(itemsPerPage * (page - 1)).limit(itemsPerPage).sort({'createdAt' : -1});
+    const messages = await messageModel
+      .find({
+        $or: [{ sender: userId }, { receiver: userId }],
+      })
+      .skip(itemsPerPage * (page - 1))
+      .limit(itemsPerPage)
+      .sort({ createdAt: -1 });
     return messages;
   } catch (error) {
     console.error(error);
@@ -25,18 +25,22 @@ export const getAllMessages = async (
 export const getConversationBtwUsers = async (
   senderId: mongoose.Types.ObjectId,
   receiverNickname: string,
-  page : number
-  ) => {
+  page: number,
+) => {
   try {
-    const receiver = await User.find({ "nickname" : receiverNickname });
+    const receiver = await User.find({ nickname: receiverNickname });
     const receiverId = receiver[0]._id;
     const itemsPerPage = 10;
-    const messages = await messageModel.find({
-      $or: [
-        { sender: senderId, receiver: receiverId },
-        { sender: receiverId, receiver: senderId },
-      ],
-    }).skip(itemsPerPage * (page - 1)).limit(itemsPerPage).sort({'createdAt' : -1});
+    const messages = await messageModel
+      .find({
+        $or: [
+          { sender: senderId, receiver: receiverId },
+          { sender: receiverId, receiver: senderId },
+        ],
+      })
+      .skip(itemsPerPage * (page - 1))
+      .limit(itemsPerPage)
+      .sort({ createdAt: -1 });
     return messages;
   } catch (error) {
     console.error(error);
@@ -44,16 +48,18 @@ export const getConversationBtwUsers = async (
 };
 
 export const createMessage = async (messageData: {
-  sender: IUser;
+  senderId: mongoose.Types.ObjectId;
   receiverNickname: string;
   content: string;
 }) => {
   try {
-    const receiver = await User.find({ 'nickname' : messageData.receiverNickname });
+    const receiver = await User.find({
+      nickname: messageData.receiverNickname,
+    });
     const newMessage = new messageModel({
-      "sender" : messageData.sender._id,
-      "receiver" : receiver[0]._id,
-      "content" : messageData.content
+      sender: messageData.senderId,
+      receiver: receiver[0]._id,
+      content: messageData.content,
     });
     const createdMessage = await newMessage.save();
     return createdMessage;

--- a/src/service/postService.ts
+++ b/src/service/postService.ts
@@ -2,11 +2,18 @@ import mongoose from 'mongoose';
 import postModel from '../models/postModel';
 import { IUser } from '../models/userModel';
 
-export const getAllPosts = async (user : IUser, page : number) => {
+export const getAllPosts = async (
+  userId: mongoose.Types.ObjectId,
+  page: number,
+) => {
   try {
     const itemsPerPage = 10;
     //최신순으로 pagination 된 데이터를 받아 온다.
-    const posts = await postModel.find().skip(itemsPerPage * (page - 1)).limit(itemsPerPage).sort({'createdAt' : -1});
+    const posts = await postModel
+      .find()
+      .skip(itemsPerPage * (page - 1))
+      .limit(itemsPerPage)
+      .sort({ createdAt: -1 });
     return posts;
   } catch {
     console.error('error');

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -1,6 +1,7 @@
 import nodemailer from 'nodemailer';
 
 export const sendAuthEmail = async (
+  url: string,
   name: string,
   emailTo: string,
   certificateToken: string,
@@ -21,9 +22,7 @@ export const sendAuthEmail = async (
         <h2>안녕하세요 ${name}님</h2>
         <p>KUPPLY에 회원가입해주셔서 감사합니다. 아래 링크로 이동해 회원가입을 완료해주세요!</p>
         <p>만약에 실수로 요청하셨거나, 본인이 요청하지 않았다면, 이 메일을 무시하세요.</p>
-        <a href=http://${process.env.HOST || 'localhost'}:${
-          process.env.PORT || 8080
-        }/certify/${certificateToken}> 계속하기</a>
+        <a href=${url}/certify/${certificateToken}> 계속하기</a>
         </div>`,
   };
 

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -21,7 +21,7 @@ export const sendAuthEmail = async (
         <h2>안녕하세요 ${name}님</h2>
         <p>KUPPLY에 회원가입해주셔서 감사합니다. 아래 링크로 이동해 회원가입을 완료해주세요!</p>
         <p>만약에 실수로 요청하셨거나, 본인이 요청하지 않았다면, 이 메일을 무시하세요.</p>
-        <a href=http://localhost:${
+        <a href=http://${process.env.HOST || 'localhost'}:${
           process.env.PORT || 8080
         }/certify/${certificateToken}> 계속하기</a>
         </div>`,

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,14 +1,20 @@
 import jwt from 'jsonwebtoken';
-import User, { IUser } from '../models/userModel';
+import { Types } from 'mongoose';
+import { IUser } from '../models/userModel';
 
 interface JwtPayload {
-  id: string;
+  id: Types.ObjectId;
+  role: string;
 }
 
 export const createToken = (user: IUser) => {
-  const accessToken = jwt.sign({ id: user._id }, process.env.JWT_SECRET_KEY!, {
-    expiresIn: '1h',
-  });
+  const accessToken = jwt.sign(
+    { id: user._id, role: user.role },
+    process.env.JWT_SECRET_KEY!,
+    {
+      expiresIn: '1h',
+    },
+  );
 
   return accessToken;
 };
@@ -23,7 +29,7 @@ export const createRefreshToken = () => {
 
 export const createCertificateToken = (user: IUser) => {
   const accessToken = jwt.sign(
-    { id: user._id },
+    { id: user._id, role: user.role },
     process.env.JWT_CERTIFICATE_SECRET_KEY!,
     {
       expiresIn: '1h',
@@ -35,12 +41,12 @@ export const createCertificateToken = (user: IUser) => {
 
 export const verifyToken = (accessToken: string) => {
   try {
-    const { id } = jwt.verify(
+    const { id, role } = jwt.verify(
       accessToken,
       process.env.JWT_SECRET_KEY!,
     ) as JwtPayload;
 
-    return id;
+    return { id, role };
   } catch (err) {
     return null;
   }
@@ -56,6 +62,6 @@ export const verifyRefreshToken = (refreshToken: string) => {
 };
 
 export const decodeToken = (accessToken: string) => {
-  const { id } = jwt.decode(accessToken) as JwtPayload;
-  return id;
+  const { id, role } = jwt.decode(accessToken) as JwtPayload;
+  return { id, role };
 };


### PR DESCRIPTION
1. jwt 토큰 구조 변경
- jwt 토큰에 user id만이 아니라 role도 저장.
- 따라서 이제 Express Request에 user가 아니라 user id와 user role을 추가.' req.userId'와 'req.userRole'로 접근 가능.
- 기존에 'req.user' 사용한 코드들 수정했는데, 기능들 완벽하게 되는지는 다 확인 못함. 일단 message와 post는 되는 거 확인.
- 기존에 로그인한 유저인지 확인할 때, accessToken이 유효하든, 유효하지 않든 디비에 접근했는데, 이제는 accessToken이 유효하지 않을 때만 refreshToken을 읽기 위해 디비 접근하도록 수정함.

2. 이메일
- 이메일이 성공적으로 보내진 후에 디비에 유저 정보 저장하도록 변경.
- 인증링크 생성할 때 Request에서 protocol(http인지 https인지)과 host 읽어서 생성하도록 변경. 그래서 .env에 따로 추가 안해도 됨.