### PR TITLE
userModel.ts에 pending에서 active로 인증되지 않으면 자동 삭제되게 수정했습니다

### DIFF
--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -160,10 +160,14 @@ export const certifyUser = async (certificateToken: string) => {
   const { id } = jwt.decodeToken(certificateToken);
   const updatedUser = await User.findByIdAndUpdate(
     id,
-    { certificate: 'active' },
+    { 
+      certificate: 'active',
+      expiresAt: null,  
+    },
     {
       new: true,
     },
+    
   );
 
   if (!updatedUser)


### PR DESCRIPTION
인증 제한 시간은 2분으로 설정했는데 직접 확인해보니 데이터 삭제까지는 4.5분정도 걸립니다.
인증 제한 시간이 지나도 데이터가 삭제되지 않아서 4.5분 안에는 이메일 링크타면 pending -> active 변하는게 확인됩니다.
나중에 재인증이 필요하다면 5분후에 다시 인증하는 것으로 명시하는게 좋을 것 같습니다. 