### PR TITLE
Fix: 이메일 인증방식 변경

### DIFF
--- a/src/controller/authController.ts
+++ b/src/controller/authController.ts
@@ -3,10 +3,9 @@ import * as authService from '../service/authService';
 
 export const join = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const url: string = `${req.protocol}://${req.get('host')}`;
     const userData = req.body;
     // FIXME: 지금은 테스트를 위해서 유저 정보를 리턴받는데 나중에는 안 받아도 됨.
-    const newUser = await authService.join(url, userData);
+    const newUser = await authService.join(userData);
 
     res.status(201).json({
       status: 'success',
@@ -88,15 +87,39 @@ export const protect = async (
   }
 };
 
-export const certifyUser = async (
+export const sendEmail = async (
   req: Request,
   res: Response,
   next: NextFunction,
 ) => {
   try {
-    await authService.certifyUser(req.params.certificateToken);
+    const { email } = req.body;
 
-    res.redirect('/');
+    await authService.sendEmail(email);
+
+    res.status(200).json({
+      status: 'success',
+      message: 'Email sent successfully',
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const certifyEmail = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const { email, code } = req.body;
+
+    await authService.certifyEmail(email, code);
+
+    res.status(200).json({
+      status: 'success',
+      message: 'Email verified successfully',
+    });
   } catch (err) {
     next(err);
   }

--- a/src/models/emailModel.ts
+++ b/src/models/emailModel.ts
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose';
+
+const Schema = mongoose.Schema;
+
+const emailSchema = new Schema({
+  email: {
+    type: String,
+    required: true,
+    unique: true,
+    trim: true,
+    match: /^[a-zA-Z0-9._%+-]+@korea\.ac\.kr$/,
+  },
+  code: {
+    type: String,
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now() + 9 * 60 * 60 * 1000,
+  },
+  certificate: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+export default mongoose.model('Email', emailSchema);

--- a/src/models/userModel.ts
+++ b/src/models/userModel.ts
@@ -11,7 +11,6 @@ export interface IUser extends Document {
   nickname: string;
   role: string;
   refreshToken: string;
-  certificate: string;
   secondMajor: Types.ObjectId;
   passSemester: string;
   passDescription: string;
@@ -73,11 +72,6 @@ const userSchema = new Schema<IUser>(
       type: String,
       default: null,
       select: false,
-    },
-    certificate: {
-      type: String,
-      enum: ['pending', 'active'],
-      default: 'pending',
     },
     // info of passer only
     secondMajor: {

--- a/src/router/authRouter.ts
+++ b/src/router/authRouter.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+import * as authController from '../controller/authController';
+
+const router = express.Router();
+
+router.post('/join', authController.join);
+router.post('/login', authController.login);
+router.get('/logout', authController.logout);
+router.post('/sendEmail', authController.sendEmail);
+router.post('/certifyEmail', authController.certifyEmail);
+
+export default router;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,23 +1,22 @@
 import express from 'express';
+import authRouter from './authRouter';
 import userRouter from './userRouter';
 import majorRouter from './majorRouter';
 import dashboardRouter from './dashboard';
 import postRouter from './postRouter';
 import messageRouter from './messageRouter';
-import pastDataRouter from './pastDataRouter'
+import pastDataRouter from './pastDataRouter';
 import * as authController from '../controller/authController';
 
 const router = express.Router();
 
-router.post('/join', authController.join);
-router.post('/login', authController.login);
-router.get('/logout', authController.logout);
-router.get('/certify/:certificateToken', authController.certifyUser);
+router.use('/auth', authRouter);
 
 router.get('/', (req, res) => {
   res.send('Hello World!');
 });
 
+// FIXME: 나중에 적절한 위치로 수정
 router.use(authController.protect);
 
 router.use('/user', userRouter);

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -1,11 +1,6 @@
 import nodemailer from 'nodemailer';
 
-export const sendAuthEmail = async (
-  url: string,
-  name: string,
-  emailTo: string,
-  certificateToken: string,
-) => {
+export const sendAuthEmail = async (emailTo: string, code: string) => {
   const smtpTransport = nodemailer.createTransport({
     service: 'gmail',
     auth: {
@@ -17,13 +12,8 @@ export const sendAuthEmail = async (
   const mailOptions = {
     from: process.env.EMAIL_USER,
     to: emailTo,
-    subject: 'KUPPLY 회원가입 인증 메일',
-    html: `<h1>이메일 인증</h1>
-        <h2>안녕하세요 ${name}님</h2>
-        <p>KUPPLY에 회원가입해주셔서 감사합니다. 아래 링크로 이동해 회원가입을 완료해주세요!</p>
-        <p>만약에 실수로 요청하셨거나, 본인이 요청하지 않았다면, 이 메일을 무시하세요.</p>
-        <a href=${url}/certify/${certificateToken}> 계속하기</a>
-        </div>`,
+    subject: 'KUPPLY 회원가입 인증번호',
+    html: `인증번호: ${code}`,
   };
 
   await smtpTransport.sendMail(mailOptions);


### PR DESCRIPTION
링크에서 인증코드로 메일 인증 방식을 변경했습니다.

먼저 userModel에서 기존에 있던 'certificate' 필드를 제거하고, 이메일 인증 만을 위해서 emailModel을 추가했습니다. 

회원가입 제일 첫 단계로 이메일 주소만 입력해서 인증코드를 요청했을 때 '/auth/sendEmail' api url을 통해서 body에 이메일 주소를 넣어서 POST 요청을 보내면 무작위 인증 코드를 만들어서 메일을 보내고 db에 이메일 주소와 인증코드를 저장합니다. '인증번호 다시받기'도 같은 url로 보내면 되도록 했습니다.

이후에 인증코드를 입력하면 '/auth/certifyEmail' api url을 통해서 body에 email과 인증코드를 넣어서 POST 요청을 보내면 디비에서 찾아서 인증코드가 일치하는지 확인하고 제한 시간에 맞게 입력하면 200을 리턴하고 틀렸거나, 제한 시간이 만료되었다면 400을 리턴하게 했습니다.

한 가지 걱정되는 게 유저가 인증코드를 입력할 때 그 전에 입력된 유저의 이메일 주소를 기억하고 있을 수 있을까요? 인증코드를 검사할 때 지금은 이메일 주소도 필요한데, 프런트에서 이게 구현이 될 지 모르겠어서..