### PR TITLE
feat: 임시 비밀번호 발급, 비밀번호 변경 기능

### DIFF
--- a/src/controller/authController.ts
+++ b/src/controller/authController.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
+import { Types } from 'mongoose';
 import * as authService from '../service/authService';
 
 export const join = async (req: Request, res: Response, next: NextFunction) => {
@@ -10,7 +11,7 @@ export const join = async (req: Request, res: Response, next: NextFunction) => {
     res.status(201).json({
       status: 'success',
       data: {
-        message: `${newUser.email}로 인증 링크를 보냈습니다. 이메일 인증을 하여 회원가입을 완료해주세요.`,
+        message: `회원가입이 완료되었습니다.`,
         user: newUser,
       },
     });
@@ -35,7 +36,7 @@ export const login = async (
       expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
       httpOnly: true,
     });
-    if(isRememberOn){
+    if (isRememberOn) {
       res.cookie('refreshToken', refreshToken, {
         expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
         httpOnly: true,
@@ -139,6 +140,43 @@ export const nicknameCheck = async (
 
     res.status(200).json({
       isSuccess: isSuccess,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const forgotPassword = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const { userEmail } = req.body;
+    await authService.forgotPassword(userEmail);
+
+    res.status(200).json({
+      status: 'success',
+      message: `${userEmail}로 임시 비밀번호를 보냈습니다.`,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const resetPassword = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const userId = req.userId as Types.ObjectId;
+    const { newPassword } = req.body;
+
+    await authService.resetPassword(userId, newPassword);
+
+    res.status(200).json({
+      status: 'success',
     });
   } catch (err) {
     next(err);

--- a/src/controller/authController.ts
+++ b/src/controller/authController.ts
@@ -58,6 +58,8 @@ export const login = async (
 
 export const logout = async (req: Request, res: Response) => {
   await authService.logout(req.cookies.accessToken);
+  req.userId = undefined;
+  req.userRole = undefined;
   res.clearCookie('accessToken', { httpOnly: true });
   res.clearCookie('refreshToken', { httpOnly: true });
   res.status(200).json({ status: 'success' });
@@ -171,12 +173,13 @@ export const resetPassword = async (
 ) => {
   try {
     const userId = req.userId as Types.ObjectId;
-    const { newPassword } = req.body;
+    const { oldPassword, newPassword } = req.body;
 
-    await authService.resetPassword(userId, newPassword);
+    await authService.resetPassword(userId, oldPassword, newPassword);
 
     res.status(200).json({
       status: 'success',
+      message: '비밀번호가 성공적으로 변경되었습니다.',
     });
   } catch (err) {
     next(err);

--- a/src/models/emailModel.ts
+++ b/src/models/emailModel.ts
@@ -15,7 +15,7 @@ const emailSchema = new Schema({
   },
   createdAt: {
     type: Date,
-    default: Date.now() + 9 * 60 * 60 * 1000,
+    default: Date.now(),
   },
   certificate: {
     type: Boolean,

--- a/src/models/emailModel.ts
+++ b/src/models/emailModel.ts
@@ -15,7 +15,9 @@ const emailSchema = new Schema({
   },
   createdAt: {
     type: Date,
-    default: Date.now(),
+    default: function () {
+      return Date.now();
+    },
   },
   certificate: {
     type: Boolean,

--- a/src/models/userModel.ts
+++ b/src/models/userModel.ts
@@ -8,7 +8,6 @@ export interface IUser extends Document {
   phoneNumber: string;
   email: string;
   firstMajor: Types.ObjectId;
-  name: string;
   nickname: string;
   role: string;
   refreshToken: string;
@@ -58,11 +57,6 @@ const userSchema = new Schema<IUser>(
       type: Schema.Types.ObjectId,
       ref: 'Major',
       required: true,
-    },
-    name: {
-      type: String,
-      required: [true, 'User must have a name.'],
-      trim: true,
     },
     nickname: {
       type: String,

--- a/src/router/authRouter.ts
+++ b/src/router/authRouter.ts
@@ -9,5 +9,7 @@ router.get('/logout', authController.logout);
 router.post('/sendEmail', authController.sendEmail);
 router.post('/certifyEmail', authController.certifyEmail);
 router.post('/nicknameCheck', authController.nicknameCheck);
+router.post('/forgotPassword', authController.forgotPassword);
+router.post('/resetPassword', authController.resetPassword);
 
 export default router;

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -2,21 +2,34 @@ import nodemailer from 'nodemailer';
 import dotenv from 'dotenv';
 
 dotenv.config();
-export const sendAuthEmail = async (emailTo: string, code: string) => {
-  console.log(process.env.EMAIL_USER, process.env.EMAIL_PASS);
-  const smtpTransport = nodemailer.createTransport({
-    service: 'gmail',
-    auth: {
-      user: process.env.EMAIL_USER,
-      pass: process.env.EMAIL_PASS,
-    },
-  });
+const smtpTransport = nodemailer.createTransport({
+  service: 'gmail',
+  auth: {
+    user: process.env.EMAIL_USER,
+    pass: process.env.EMAIL_PASS,
+  },
+});
 
+export const sendAuthEmail = async (emailTo: string, code: string) => {
   const mailOptions = {
     from: process.env.EMAIL_USER,
     to: emailTo,
     subject: 'KUPPLY 회원가입 인증번호',
     html: `인증번호: ${code}`,
+  };
+
+  await smtpTransport.sendMail(mailOptions);
+};
+
+export const sendTempPassword = async (
+  emailTo: string,
+  tempPassword: string,
+) => {
+  const mailOptions = {
+    from: process.env.EMAIL_USER,
+    to: emailTo,
+    subject: 'KUPPLY 임시 비밀번호',
+    html: `임시 비밀번호: ${tempPassword}`,
   };
 
   await smtpTransport.sendMail(mailOptions);


### PR DESCRIPTION
위의 기능들 이외로 회원가입 때 이메일 인증 과정을 변경했습니다.

이제는 이메일 인증 메일을 요청하면, 이메일 모델에서 이메일이 존재하는지 확인하지 않고, 유저 모델에서 이메일이 존해하는지 확인합니다. 유저 모델에 없으면 인증 코드를 만들어서 보내고, 있으면 이미 회원가입을 완료한 이메일이라고 알립니다.
회원가입 도중에 그만두고 나중에 다시 회원가입 하려고 재시도 하더라도 유저 모델에는 존재하지 않기에, 인증 코드를 보낼 수 있습니다.

그래서 이메일 인증 코드를 인증할 때, 코드가 맞다면 바로 이메일 모델에서 certificate을 true로 바꿉니다. 그리고 이후에 join 함수에서 먼저 이메일 모델에서 이메일 인증을 완료한 이메일인지 확인합니다.

